### PR TITLE
Use commoditity precision when writing amounts

### DIFF
--- a/gnucash.py
+++ b/gnucash.py
@@ -1,6 +1,7 @@
 import sqlite3
 import sys
 import os
+import math
 from datetime import datetime
 
 
@@ -21,6 +22,7 @@ class Commodity(object):
         self.fullname = ""
         self.mnemonic = ""
         self.namespace = ""
+        self.precision = 2
         self.prices = []
 
     def __str__(self):
@@ -93,12 +95,13 @@ def read_data(connection):
     c = connection.cursor()
 
     data = GnuCashData()
-    for row in c.execute('SELECT guid, namespace, mnemonic, fullname FROM commodities'):
-        guid, namespace, mnemonic, fullname = row
+    for row in c.execute('SELECT guid, namespace, mnemonic, fullname, fraction FROM commodities'):
+        guid, namespace, mnemonic, fullname, fraction = row
         comm = get_commodity(data, guid)
         comm.namespace = namespace
         comm.mnemonic = mnemonic
         comm.fullname = fullname
+        comm.precision = int(math.log10(fraction))
 
     for row in c.execute('SELECT guid, name, account_type, commodity_guid, commodity_scu, non_std_scu, parent_guid, code, description FROM accounts'):
         guid, name, account_type, commodity_guid, commodity_scu, non_std_scu, \

--- a/gnucash2ledger.py
+++ b/gnucash2ledger.py
@@ -81,13 +81,15 @@ for trans in transactions:
         out.write("\t%-40s  " % full_acc_name(split.account))
         trans_currency = format_commodity(trans.currency)
         if split.account.commodity != trans.currency:
+            commodity_precision = split.account.commodity.precision
             split_acc_commodity = format_commodity(split.account.commodity)
             quantity = split.quantity
             value = abs(split.value)
-            out.write("%10.2f %s @@ %.2f %s" %
-                      (quantity, split_acc_commodity, value, trans_currency))
+            out.write("%10.*f %s @@ %.2f %s" %
+                      (commodity_precision, quantity, split_acc_commodity, value, trans_currency))
         else:
-            out.write("%10.2f %s" % (split.value, trans_currency))
+            commodity_precision = trans.currency.precision
+            out.write("%10.*f %s" % (commodity_precision, split.value, trans_currency))
         if split.memo:
             out.write("  ; %s" % no_nl(split.memo))
         out.write("\n")


### PR DESCRIPTION
Some commodities, like mutual funds, can be purchased in very small increments.  To avoid loosing precision when converting from GnuCash, use the commodity precision instead of always assuming 2 decimal places.